### PR TITLE
Fix a bug that can't show a map.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,12 +5,12 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <script src="//cdn.rawgit.com/mahnunchik/markerclustererplus/master/dist/markerclusterer.min.js"></script>
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
 
     <!-- google mapを表示するために必要 -->
     <script src="//maps.google.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_JS_API'] %>"</script>
-    <script src="//cdn.rawgit.com/mahnunchik/markerclustererplus/master/dist/markerclusterer.min.js"></script>
     <script src='//cdn.rawgit.com/printercu/google-maps-utility-library-v3-read-only/master/infobox/src/infobox_packed.js'　type='text/javascript'></script>
   </head>
 


### PR DESCRIPTION
こんにちは。

グーグルマップが表示されなかったのを修正しましたので確認願います(関連するイシュー:  #16 )。

原因としては、JavaScriptの読み込み順が違っており、参照しようとした`MarkerClusterer`が存在せずエラーになっていました。
(この辺の話は @himajin315 さんが詳しいと思います)。

それでは。