### PR TITLE
Delete email

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,13 +4,13 @@ class SessionsController < ApplicationController
   end
 
   def create
-    user = User.find_by(email: params[:session][:email].downcase)
+    user = User.find_by(name: params[:session][:name])
     if user && user.authenticate(params[:session][:password])
       log_in user
       remember user
       redirect_to board_path
     else
-      flash.now[:danger] = 'Eメールとパスワードが一致しませんでした。'
+      flash.now[:danger] = 'ユーザーネームとパスワードが一致しませんでした。'
       render 'new'
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,6 +17,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation)
+    params.require(:user).permit(:name, :password, :password_confirmation)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ApplicationRecord
   class << self
     #検索する
     def search(search, user)
-      if search
+      unless search == "" or search.nil?
         User.where("name LIKE ?", "%#{search}%").where.not(name: "#{user}")
       end
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,12 +3,7 @@ class User < ApplicationRecord
   has_many :middles, dependent: :destroy
 
   attr_accessor :remember_token
-  before_save { self.email = email.downcase }
-  validates :name,  presence: true, length: { maximum: 50 }
-  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
-  validates :email, presence: true, length: { maximum: 255 },
-                    format: { with: VALID_EMAIL_REGEX },
-                    uniqueness: { case_sensitive: false }
+  validates :name, uniqueness: true, presence: true, length: { maximum: 20 }
   has_secure_password
   validates :password, presence: true, length: { minimum: 6 }
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -8,8 +8,8 @@
       <p><% flash[:danger] %></p>
       <h1>ログインページ</h1>
       <%= form_for(:session, url: login_path) do |f| %>
-        <%= f.label :email,"Eメール" %>
-        <%= f.email_field :email, class: "form-control mb-2 mr-sm-2" %>
+        <%= f.label :name,"ユーザーネーム" %>
+        <%= f.text_field :name, class: "form-control mb-2 mr-sm-2" %>
         <%= f.label :password,"パスワード" %>
         <%= f.password_field :password, class: "form-control mb-2 mr-sm-2" %>
         <p>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -9,14 +9,8 @@
         <%if msg =="Name translation missing: ja.activerecord.errors.models.user.attributes.name.blank" %>
           <li>ユーザーネームを入力してください</li>
         <% end %>
-        <%if msg =="Email translation missing: ja.activerecord.errors.models.user.attributes.email.blank" %>
-          <li>Eメールを入力してください</li>
-        <% end %>
-        <%if msg =="Email translation missing: ja.activerecord.errors.models.user.attributes.email.invalid" %>
-          <li>Eメールが間違っています</li>
-        <% end %>
-        <%if msg =="Email translation missing: ja.activerecord.errors.models.user.attributes.email.taken" %>
-          <li>このEメールは登録されています</li>
+        <%if msg =="Name translation missing: ja.activerecord.errors.models.user.attributes.name.taken" %>
+          <li>このユーザーネームはすでに使われています</li>
         <% end %>
         <%if msg =="Password translation missing: ja.activerecord.errors.models.user.attributes.password.blank" %>
           <li>パスワードを入力してください</li>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -12,8 +12,6 @@
 
         <%= f.label :name, "ユーザーネーム" %>
         <%= f.text_field :name, class: "form-control mb-2 mr-sm-2" %>
-        <%= f.label :email, "Eメール" %>
-        <%= f.email_field :email, class: "form-control mb-2 mr-sm-2" %>
         <%= f.label :password, "パスワード" %>
         <%= f.password_field :password, class: "form-control mb-2 mr-sm-2" %>
         <%= f.label :password_confirmation, "確認用パスワード" %>

--- a/db/migrate/20181227055956_remove_email_from_users.rb
+++ b/db/migrate/20181227055956_remove_email_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveEmailFromUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_17_054646) do
+ActiveRecord::Schema.define(version: 2018_12_27_055956) do
 
   create_table "boards", force: :cascade do |t|
     t.string "location"
@@ -46,7 +46,6 @@ ActiveRecord::Schema.define(version: 2018_12_17_054646) do
 
   create_table "users", force: :cascade do |t|
     t.string "name"
-    t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "password_digest"


### PR DESCRIPTION
共有する相手を検索するとき、空白で検索したら全員出てきたのを誰も出なくするようにしました。
Userモデルからemailのカラムを消してユーザー登録やログインが前よりも楽になりました。
また、それに対応したエラーメッセージをつけました。

お時間があるときに確認よろしくお願いします。