### PR TITLE
情報記入ページで表示ページに戻るをクリックするとルートが消える仕様を無くしました

### DIFF
--- a/app/views/boards/entry_form.html.erb
+++ b/app/views/boards/entry_form.html.erb
@@ -18,7 +18,7 @@
           </div>
         <% end %>
         <p>
-          <%= link_to "表示ページに戻る", boards_show_path(@board.id) %>
+          <%= link_to "表示ページに戻る", boards_show_path(@board.id),data: {"turbolinks" => false}%>
         </p>
       </div>
     </div><!--Bootstrapのグリッドシステムの対象範囲-->

--- a/app/views/boards/mood_form.html.erb
+++ b/app/views/boards/mood_form.html.erb
@@ -18,7 +18,7 @@
         </div>
       <% end %>
       <p>
-        <%= link_to "表示ページに戻る", boards_show_path(@board.id) %>
+        <%= link_to "表示ページに戻る", boards_show_path(@board.id),data: {"turbolinks" => false} %>
       </p>
       </div>
     </div><!--Bootstrapのグリッドシステムの対象範囲-->

--- a/app/views/boards/wave_form.html.erb
+++ b/app/views/boards/wave_form.html.erb
@@ -41,7 +41,7 @@
       </div>
     <% end %>
     <p>
-      <%= link_to "表示ページに戻る", boards_show_path(@board.id) %>
+      <%= link_to "表示ページに戻る", boards_show_path(@board.id),data: {"turbolinks" => false} %>
     </p>
     </div>
   </div><!--Bootstrapのグリッドシステムの対象範囲-->


### PR DESCRIPTION
上記の状態をdata: {"turbolinks" => false}を追加することで修正しました
確認よろしくです